### PR TITLE
fix: don't require explicitly installed pkgs on arch

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -177,7 +177,7 @@ run_installation()
                 echo "Check Dependecies for $KERNEL"
                 echo "If the dependencies are not met, run the follow:"
                 echo "    sudo pacman -S libphonenumber cmake boost gtest"
-                fail_check pacman -Qe libphonenumber cmake boost gtest
+                fail_check pacman -Q libphonenumber cmake boost gtest
                 install_libphonenumber
                 ;;
             CentOS|Amazon)


### PR DESCRIPTION
Running `pacman` with the flag `-Qe` only returns successfully
if the packages have been installed explicitly. If any of them
happen to be installed as a dependency for other packages, the
check fails. Fix this by removing `-e`.